### PR TITLE
add implementation of Damerau-Levenshtein

### DIFF
--- a/livingdoc-engine/build.gradle
+++ b/livingdoc-engine/build.gradle
@@ -1,4 +1,17 @@
+buildscript {
+    ext.kotlin_version = '1.1.2-4'
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0-M4'
+    }
+}
+
 apply plugin: 'java'
+apply plugin: 'kotlin'
+apply plugin: 'org.junit.platform.gradle.plugin'
 
 sourceCompatibility = 1.8
 
@@ -7,7 +20,12 @@ repositories {
 }
 
 dependencies {
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
 
+    testCompile 'org.assertj:assertj-core:3.6.2'
+    testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.0-M4'
+    testCompile 'org.junit.jupiter:junit-jupiter-params:5.0.0-M4'
+    testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.0-M4'
 }
 
 task javadocJar(type: Jar) {
@@ -24,3 +42,4 @@ artifacts {
     archives(javadocJar)
     archives(sourcesJar)
 }
+

--- a/livingdoc-engine/src/main/java/org/livingdoc/engine/algo/DamerauLevenshtein.kt
+++ b/livingdoc-engine/src/main/java/org/livingdoc/engine/algo/DamerauLevenshtein.kt
@@ -1,0 +1,98 @@
+package org.livingdoc.engine.algo
+
+import java.lang.Math.min
+
+/**
+ * Calculates the Damerau-Levenshtein distance, a string similarity metric used e.g. by spell checkers.
+ *
+ * By default, the algorithm calculates the minimum number of four different editing operations
+ * required to turn one string into another. The four operations are
+ * <ul>
+ *     <li><emph>insertion:</emph> a character is inserted</li>
+ *     <li><emph>deletion:</emph> a character is deleted</li>
+ *     <li><emph>substitution:</emph> a character is exchanged with another</li>
+ *     <li><emph>transposition:</emph> two adjacent characters are swapped</li>
+ * </ul>
+ *
+ * It is possible to specify a weight for each of these operations to tune the metric.
+ *
+ * The implementation is linear in space, but O(n²) in time. To avoid expensive comparisons of long
+ * strings, you can specify a cutoff distance, beyond which the algorithm will abort.
+ *
+ * @param cutoffDistance maximum distance at which the algorithm aborts (default: no cutoff)
+ * @param weightInsertion weight of an insert operation (default: 1)
+ * @param weightDeletion weight of a deletion operation (default: 1)
+ * @param weightSubstitution weight of a substitution operation (default: 1)
+ * @param weightTransposition weight of a transposition operation (default: 1)
+ */
+class DamerauLevenshtein(val cutoffDistance: Int = 0,
+                         val weightInsertion: Int = 1,
+                         val weightDeletion: Int = 1,
+                         val weightSubstitution: Int = 1,
+                         val weightTransposition: Int = 1) {
+
+    /*
+     * This dynamic programming algorithm calculates a m*n matrix of distance values. The
+     * final result is the distance between the two given strings a and b. The values in between
+     * are locally minimal distances for the respective substrings of a and b.
+     *
+     *     L i v i n g D o c - b
+     *    0 1 2 3 4 5 6 7 8 9
+     * L  1 0 2 3 4 5 6 7 8 9
+     * o  2 1 1 2 3 4 5 6 7 8
+     * v  3 2 2 1 2 3 4 5 6 7
+     * i  4 3 2 2 1 2 3 4 5 6
+     * g  5 4 3 3 2 2 3 4 5 6
+     * n  6 5 4 4 3 2 2 3 4 5
+     * D  7 6 5 5 4 3 3 2 3 4
+     * e  8 7 6 6 5 4 4 3 3 4
+     * a  9 8 7 7 6 5 5 4 4 4
+     * d 10 9 8 8 7 6 6 5 5 5 <-- distance result
+     * |
+     * a
+     *
+     * As only the last three rows are needed to calculate the next distance value, only those are kept
+     * in memory.
+     */
+
+    /**
+     * Calculates the editing distance between the given strings.
+     */
+    fun distance(a: String, b: String): Int {
+        var secondToLastRow = IntArray(b.length + 1)
+        var lastRow = IntArray(b.length + 1)
+        var currentRow = IntArray(b.length + 1)
+
+        for (j in 0..b.length) {
+            lastRow[j] = j * weightInsertion
+        }
+
+        for (i in 0 until a.length) {
+            var currentDistance = Int.MAX_VALUE
+            currentRow[0] = (i + 1) * weightDeletion
+
+            for (j in 0 until b.length) {
+                currentRow[j + 1] = currentRow[j] + weightInsertion
+                currentRow[j + 1] = min(currentRow[j + 1], lastRow[j + 1] + weightDeletion)
+                currentRow[j + 1] = min(currentRow[j + 1], lastRow[j] + if (a[i] != b[j]) weightSubstitution else 0)
+                if (i > 0 && j > 0 && a[i - 1] == b[j] && a[i] == b[j - 1]) {
+                    currentRow[j + 1] = min(currentRow[j + 1], secondToLastRow[j - 1] + weightTransposition)
+                }
+
+                currentDistance = min(currentDistance, currentRow[j + 1])
+            }
+            // check cutoff
+            if (cutoffDistance > 0 && currentDistance >= cutoffDistance) {
+                return currentDistance
+            }
+
+            // rotate rows
+            val tempRow = secondToLastRow
+            secondToLastRow = lastRow
+            lastRow = currentRow
+            currentRow = tempRow
+        }
+
+        return lastRow[b.length]
+    }
+}

--- a/livingdoc-engine/src/test/java/org/livingdoc/engine/algo/DamerauLevenshteinTest.kt
+++ b/livingdoc-engine/src/test/java/org/livingdoc/engine/algo/DamerauLevenshteinTest.kt
@@ -1,0 +1,79 @@
+package org.livingdoc.engine.algo
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+
+class DamerauLevenshteinTest {
+
+    val cut = DamerauLevenshtein()
+
+    @ParameterizedTest
+    @ValueSource(strings = arrayOf("", "a", "LivingDoc"))
+    fun identicalStringsHaveDistanceOfZero(a: String) {
+        assertThat(cut.distance(a, a)).isEqualTo(0)
+    }
+
+    @Test
+    fun insertionsAndDeletionsAreCountedCorrectly() {
+        assertThat(cut.distance("", "LivingDoc")).isEqualTo(9)
+        assertThat(cut.distance("LivingDoc", "")).isEqualTo(9)
+        assertThat(cut.distance("Living", "LivingDoc")).isEqualTo(3)
+        assertThat(cut.distance("LivingDoc", "Living")).isEqualTo(3)
+    }
+
+    @Test
+    fun substitutionsAreCountedCorrectly() {
+        assertThat(cut.distance("Test-It", "Tast-It")).isEqualTo(1)
+        assertThat(cut.distance("Test-It", "Tast-Et")).isEqualTo(2)
+    }
+
+    @Test
+    fun swappingAdjacentCharactersCountsOnlyOnce() {
+        assertThat(cut.distance("LivingDoc", "LviingDoc")).isEqualTo(1)
+        assertThat(cut.distance("LivingDoc", "LviingoDc")).isEqualTo(2)
+    }
+
+    @Test
+    fun returnsCutoffDistanceWhenDistanceIsTooLarge() {
+        assertThat(cut.distance(
+                "he adds '{}' to his shopping cart",
+                "the user '{}' is logged into the shop")).isEqualTo(25)
+        val withCutoffDistance = DamerauLevenshtein(cutoffDistance = 12)
+        assertThat(withCutoffDistance.distance(
+                "he adds '{}' to his shopping cart",
+                "the user '{}' is logged into the shop")).isEqualTo(12)
+    }
+
+    @Test
+    fun canConfigureWeightsOfInsertionsAndDeletions() {
+        assertThat(cut.distance("Living", "ingDoc")).isEqualTo(6)
+        val withExpensiveInsertionsAndDeletions = DamerauLevenshtein(weightDeletion = 2, weightInsertion = 2)
+        assertThat(withExpensiveInsertionsAndDeletions.distance("Living", "ingDoc")).isEqualTo(6)
+    }
+
+    @Test
+    fun canConfigureWeightOfSubstitutions() {
+        assertThat(cut.distance("Living", "Loving")).isEqualTo(1)
+        val withExpensiveSubstitutions = DamerauLevenshtein(
+                weightDeletion = 3,
+                weightInsertion = 3,
+                weightSubstitution = 2)
+        assertThat(withExpensiveSubstitutions.distance("Living", "Loving")).isEqualTo(2)
+    }
+
+    @Test
+    fun canConfigureWeightOfTranspositions() {
+        assertThat(cut.distance("Living", "Livign")).isEqualTo(1)
+        val withExpensiveTranspositions = DamerauLevenshtein(
+                weightDeletion = 3,
+                weightInsertion = 3,
+                weightSubstitution = 3,
+                weightTransposition = 2)
+        assertThat(withExpensiveTranspositions.distance("Living", "Livign")).isEqualTo(2)
+    }
+
+}
+


### PR DESCRIPTION
Damerau-Levenshtein is a string similarity metric used in natural language processing (e.g. your spell checker). It calculates the number of editing operations required to turn one string into the other.

Example:
`d("he adds '{}' to his shopping cart", "she also adds '{}' to her shopping cart") = 8`
`d("he adds '{}' to his shopping cart", "the user '{}' is logged into the shop") = 25`

My idea is to use this for matching slightly different scenario step descriptions to the same fixture method. This is an alternative to the string matching DSL proposed by @slu-it in https://gist.github.com/slu-it/a8a58cdc3b4697e5e3df23d3f126e76a. What do you think?