### PR TITLE
added @Testable to document binding in order to enable IDE support

### DIFF
--- a/livingdoc-fixture-api/build.gradle
+++ b/livingdoc-fixture-api/build.gradle
@@ -13,6 +13,14 @@ apply plugin: 'org.asciidoctor.convert'
 
 sourceCompatibility = 1.8
 
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly "org.junit.platform:junit-platform-commons:1.0.0-M4"
+}
+
 task javadocJar(type: Jar) {
     classifier = 'javadoc'
     from javadoc

--- a/livingdoc-fixture-api/src/main/java/org/livingdoc/fixture/api/binding/ExecutableDocument.java
+++ b/livingdoc-fixture-api/src/main/java/org/livingdoc/fixture/api/binding/ExecutableDocument.java
@@ -5,7 +5,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.junit.platform.commons.annotation.Testable;
 
+
+@Testable
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ExecutableDocument {


### PR DESCRIPTION
The dependency to the JUnit Platform is compile time only and therefore not transitive. No one HAS to have JUnit on the class path in order to use `@ExecutableDocument`, but if our JUnit Engine is used, classes annotated with it will be recognized by the IDE as "testable" and allow an execution.

The answer to "Will the `@Testable` annotation lead to problems if JUnit is not on the classpath?":
https://stackoverflow.com/questions/29396824/java-runtime-retention-annotations-annotation-class-required-at-compile-time-b