### PR TITLE
Type converters

### DIFF
--- a/livingdoc-converters/build.gradle
+++ b/livingdoc-converters/build.gradle
@@ -20,9 +20,11 @@ repositories {
 }
 
 dependencies {
+    compile "org.slf4j:slf4j-api:1.7.25"
     compile("org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version")
     compile(project(':livingdoc-api'))
 
+    testCompile 'ch.qos.logback:logback-classic:1.2.3'
     testCompile('org.assertj:assertj-core:3.6.2')
     testCompile('org.mockito:mockito-core:2.7.22')
     testCompile('com.nhaarman:mockito-kotlin:1.4.0') { transitive = false }

--- a/livingdoc-converters/build.gradle
+++ b/livingdoc-converters/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.2-5'
+    ext.kotlin_version = '1.1.3-2'
     repositories {
         mavenCentral()
     }
@@ -47,9 +47,9 @@ artifacts {
     archives(sourcesJar)
 }
 
-// Kotlin compiler settings
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
 }

--- a/livingdoc-converters/src/main/kotlin/org/livingdoc/converters/TypeConverterManager.kt
+++ b/livingdoc-converters/src/main/kotlin/org/livingdoc/converters/TypeConverterManager.kt
@@ -1,4 +1,4 @@
-package org.livingdoc.engine.fixtures
+package org.livingdoc.converters
 
 import org.livingdoc.api.conversion.TypeConverter
 import org.slf4j.Logger
@@ -13,7 +13,7 @@ import kotlin.reflect.KClass
  * 1. load and manage default type converters provided by LivingDoc
  * 2. create and cache instances of (custom) type converters
  */
-internal object TypeConverterManager {
+object TypeConverterManager {
 
     private val log: Logger = LoggerFactory.getLogger(javaClass)
 

--- a/livingdoc-converters/src/main/kotlin/org/livingdoc/converters/TypeConverters.kt
+++ b/livingdoc-converters/src/main/kotlin/org/livingdoc/converters/TypeConverters.kt
@@ -1,4 +1,4 @@
-package org.livingdoc.engine.fixtures
+package org.livingdoc.converters
 
 import org.livingdoc.api.conversion.Converter
 import org.livingdoc.api.conversion.TypeConverter
@@ -9,7 +9,7 @@ import java.lang.reflect.Parameter
 /**
  * Utility object providing [TypeConverter] related operations.
  */
-internal object TypeConverters {
+object TypeConverters {
 
     // TODO for future development
     // - inheritance >> loading converters from annotations down the inheritance stack (class level only)

--- a/livingdoc-converters/src/test/java/org/livingdoc/converters/TypeConvertersTestFixtures.java
+++ b/livingdoc-converters/src/test/java/org/livingdoc/converters/TypeConvertersTestFixtures.java
@@ -1,11 +1,11 @@
-package fixtures;
+package org.livingdoc.converters;
 
 import java.lang.reflect.AnnotatedElement;
 
-import org.livingdoc.api.documents.ExecutableDocument;
 import org.livingdoc.api.conversion.ConversionException;
 import org.livingdoc.api.conversion.Converter;
 import org.livingdoc.api.conversion.TypeConverter;
+import org.livingdoc.api.documents.ExecutableDocument;
 
 
 public class TypeConvertersTestFixtures {

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/BooleanConverterTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/BooleanConverterTest.kt
@@ -8,9 +8,9 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.livingdoc.api.conversion.ConversionException
 
 
-internal class BooleanConverterTest {
+internal class BooleanConverterTest : DefaultTypeConverterContract {
 
-    val cut = BooleanConverter()
+    override val cut = BooleanConverter()
 
     @ParameterizedTest(name = "\"{0}\" is converted to: {1}")
     @CsvSource("true, true",

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/CharacterConverterTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/CharacterConverterTest.kt
@@ -8,9 +8,9 @@ import org.junit.jupiter.params.provider.ValueSource
 import org.livingdoc.api.conversion.ConversionException
 
 
-internal class CharacterConverterTest {
+internal class CharacterConverterTest : DefaultTypeConverterContract {
 
-    val cut = CharacterConverter()
+    override val cut = CharacterConverter()
 
     @ParameterizedTest(name = "\"{0}\"")
     @ValueSource(strings = arrayOf(" ", "\t", "a", "z", "0", "9", "-", "$", "|"))

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/DefaultTypeConverterContract.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/DefaultTypeConverterContract.kt
@@ -1,0 +1,18 @@
+package org.livingdoc.converters
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.livingdoc.api.conversion.TypeConverter
+
+interface DefaultTypeConverterContract {
+
+    val cut: TypeConverter<out Any>
+
+    @Test fun `converter is automatically loaded into manager`() {
+        val converterOfType = TypeConverterManager.getDefaultConverters()
+                .filter { it.javaClass == cut.javaClass }
+                .first()
+        assertThat(converterOfType).isNotNull()
+    }
+
+}

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/StringConverterTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/StringConverterTest.kt
@@ -6,9 +6,9 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 
-internal class StringConverterTest {
+internal class StringConverterTest : DefaultTypeConverterContract {
 
-    val cut = StringConverter()
+    override val cut = StringConverter()
 
     @ParameterizedTest(name = "\"{0}\"")
     @ValueSource(strings = arrayOf("", " ", "foo", "foo bar"))

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/TypeConvertersTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/TypeConvertersTest.kt
@@ -1,11 +1,12 @@
 package org.livingdoc.engine.fixtures
 
-import fixtures.TypeConvertersTestFixtures.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.livingdoc.api.conversion.TypeConverter
 import org.livingdoc.converters.BooleanConverter
+import org.livingdoc.converters.TypeConverters
+import org.livingdoc.converters.TypeConvertersTestFixtures.*
 import kotlin.reflect.KClass
 
 

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/number/BigDecimalConverterTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/number/BigDecimalConverterTest.kt
@@ -2,9 +2,10 @@ package org.livingdoc.converters.number
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.livingdoc.converters.DefaultTypeConverterContract
 import java.math.BigDecimal
 
-internal class BigDecimalConverterTest : NumberConverterContract<BigDecimal>() {
+internal class BigDecimalConverterTest : NumberConverterContract<BigDecimal>(), DefaultTypeConverterContract {
 
     override val cut = BigDecimalConverter()
 

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/number/BigIntegerConverterTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/number/BigIntegerConverterTest.kt
@@ -2,9 +2,10 @@ package org.livingdoc.converters.number
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.livingdoc.converters.DefaultTypeConverterContract
 import java.math.BigInteger
 
-internal class BigIntegerConverterTest : NumberConverterContract<BigInteger>() {
+internal class BigIntegerConverterTest : NumberConverterContract<BigInteger>(), DefaultTypeConverterContract {
 
     override val cut = BigIntegerConverter()
 

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/number/ByteConverterTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/number/ByteConverterTest.kt
@@ -2,8 +2,9 @@ package org.livingdoc.converters.number
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.livingdoc.converters.DefaultTypeConverterContract
 
-internal class ByteConverterTest : BoundedNumberConverterContract<Byte>() {
+internal class ByteConverterTest : BoundedNumberConverterContract<Byte>(), DefaultTypeConverterContract {
 
     override val cut = ByteConverter()
 

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/number/DoubleConverterTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/number/DoubleConverterTest.kt
@@ -2,9 +2,10 @@ package org.livingdoc.converters.number
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.livingdoc.converters.DefaultTypeConverterContract
 
 
-internal class DoubleConverterTest : BoundedNumberConverterContract<Double>() {
+internal class DoubleConverterTest : BoundedNumberConverterContract<Double>(), DefaultTypeConverterContract {
 
     override val cut = DoubleConverter()
 

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/number/FloatConverterTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/number/FloatConverterTest.kt
@@ -2,8 +2,9 @@ package org.livingdoc.converters.number
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.livingdoc.converters.DefaultTypeConverterContract
 
-internal class FloatConverterTest : BoundedNumberConverterContract<Float>() {
+internal class FloatConverterTest : BoundedNumberConverterContract<Float>(), DefaultTypeConverterContract {
 
     override val cut = FloatConverter()
 

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/number/IntegerConverterTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/number/IntegerConverterTest.kt
@@ -2,8 +2,9 @@ package org.livingdoc.converters.number
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.livingdoc.converters.DefaultTypeConverterContract
 
-internal class IntegerConverterTest : BoundedNumberConverterContract<Int>() {
+internal class IntegerConverterTest : BoundedNumberConverterContract<Int>(), DefaultTypeConverterContract {
 
     override val cut = IntegerConverter()
 

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/number/LongConverterTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/number/LongConverterTest.kt
@@ -2,9 +2,10 @@ package org.livingdoc.converters.number
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.livingdoc.converters.DefaultTypeConverterContract
 
 
-internal class LongConverterTest : BoundedNumberConverterContract<Long>() {
+internal class LongConverterTest : BoundedNumberConverterContract<Long>(), DefaultTypeConverterContract {
 
     override val cut = LongConverter()
 

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/number/ShortConverterTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/number/ShortConverterTest.kt
@@ -2,8 +2,9 @@ package org.livingdoc.converters.number
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.livingdoc.converters.DefaultTypeConverterContract
 
-internal class ShortConverterTest : BoundedNumberConverterContract<Short>() {
+internal class ShortConverterTest : BoundedNumberConverterContract<Short>(), DefaultTypeConverterContract {
 
     override val cut = ShortConverter()
 

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/time/LocalDateConverterTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/time/LocalDateConverterTest.kt
@@ -2,11 +2,12 @@ package org.livingdoc.converters.time
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.livingdoc.converters.DefaultTypeConverterContract
 import java.time.LocalDate
 import java.time.LocalDate.parse
 
 
-internal class LocalDateConverterTest : TemporalConverterContract<LocalDate>() {
+internal class LocalDateConverterTest : TemporalConverterContract<LocalDate>(), DefaultTypeConverterContract {
 
     override val cut = LocalDateConverter()
 

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/time/LocalDateTimeConverterTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/time/LocalDateTimeConverterTest.kt
@@ -2,11 +2,12 @@ package org.livingdoc.converters.time
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.livingdoc.converters.DefaultTypeConverterContract
 import java.time.LocalDateTime
 import java.time.LocalDateTime.parse
 
 
-internal class LocalDateTimeConverterTest : TemporalConverterContract<LocalDateTime>() {
+internal class LocalDateTimeConverterTest : TemporalConverterContract<LocalDateTime>(), DefaultTypeConverterContract {
 
     override val cut = LocalDateTimeConverter()
 

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/time/LocalTimeConverterTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/time/LocalTimeConverterTest.kt
@@ -2,11 +2,12 @@ package org.livingdoc.converters.time
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.livingdoc.converters.DefaultTypeConverterContract
 import java.time.LocalTime
 import java.time.LocalTime.parse
 
 
-internal class LocalTimeConverterTest : TemporalConverterContract<LocalTime>() {
+internal class LocalTimeConverterTest : TemporalConverterContract<LocalTime>(), DefaultTypeConverterContract {
 
     override val cut = LocalTimeConverter()
 

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/time/OffsetDateTimeConverterTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/time/OffsetDateTimeConverterTest.kt
@@ -2,11 +2,12 @@ package org.livingdoc.converters.time
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.livingdoc.converters.DefaultTypeConverterContract
 import java.time.OffsetDateTime
 import java.time.OffsetDateTime.parse
 
 
-internal class OffsetDateTimeConverterTest : TemporalConverterContract<OffsetDateTime>() {
+internal class OffsetDateTimeConverterTest : TemporalConverterContract<OffsetDateTime>(), DefaultTypeConverterContract {
 
     override val cut = OffsetDateTimeConverter()
 

--- a/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/time/ZonedDateTimeConverterTest.kt
+++ b/livingdoc-converters/src/test/kotlin/org/livingdoc/converters/time/ZonedDateTimeConverterTest.kt
@@ -2,11 +2,12 @@ package org.livingdoc.converters.time
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.livingdoc.converters.DefaultTypeConverterContract
 import java.time.ZonedDateTime
 import java.time.ZonedDateTime.parse
 
 
-internal class ZonedDateTimeConverterTest : TemporalConverterContract<ZonedDateTime>() {
+internal class ZonedDateTimeConverterTest : TemporalConverterContract<ZonedDateTime>(), DefaultTypeConverterContract {
 
     override val cut = ZonedDateTimeConverter()
 

--- a/livingdoc-engine/build.gradle
+++ b/livingdoc-engine/build.gradle
@@ -51,9 +51,9 @@ artifacts {
     archives(sourcesJar)
 }
 
-// Kotlin compiler settings
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
 }

--- a/livingdoc-engine/src/main/kotlin/org/livingdoc/engine/fixtures/FixtureFieldInjector.kt
+++ b/livingdoc-engine/src/main/kotlin/org/livingdoc/engine/fixtures/FixtureFieldInjector.kt
@@ -1,6 +1,7 @@
 package org.livingdoc.engine.fixtures
 
 import org.livingdoc.api.conversion.TypeConverter
+import org.livingdoc.converters.TypeConverters
 import java.lang.reflect.Field
 
 class FixtureFieldInjector(

--- a/livingdoc-engine/src/main/kotlin/org/livingdoc/engine/fixtures/FixtureMethodInvoker.kt
+++ b/livingdoc-engine/src/main/kotlin/org/livingdoc/engine/fixtures/FixtureMethodInvoker.kt
@@ -1,6 +1,7 @@
 package org.livingdoc.engine.fixtures
 
 import org.livingdoc.api.conversion.TypeConverter
+import org.livingdoc.converters.TypeConverters
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 import java.lang.reflect.Parameter

--- a/livingdoc-junit-engine/build.gradle
+++ b/livingdoc-junit-engine/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.2-5'
+    ext.kotlin_version = '1.1.3-2'
     repositories {
         mavenCentral()
     }
@@ -38,9 +38,9 @@ artifacts {
     archives(sourcesJar)
 }
 
-// Kotlin compiler settings
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
 }


### PR DESCRIPTION
- Updated Kotlin Version
- moved `TypeConverters` and `TypeConverterManager` classes to the converters package
- added tests for each default converter to verify that they are loaded by default.