### PR TITLE
Enhance Step Alignment with Variable Quotation

### DIFF
--- a/livingdoc-engine/src/main/kotlin/org/livingdoc/engine/executor/scenario/Alignment.kt
+++ b/livingdoc-engine/src/main/kotlin/org/livingdoc/engine/executor/scenario/Alignment.kt
@@ -23,8 +23,15 @@ internal class Alignment(
         val step: String,
         val maxDistance: Int) {
 
+    /* To calculate an optimal global alignment of the `StepTemplate` and the String `s` representing the scenario step,
+     * we use an adapted version of the Needleman-Wunsch algorithm. The algorithm runs in two phases:
+     *
+     * 1. construct a distance matrix
+     * 2. trace an optimal path back through the matrix to the origin
+     */
+
     /**
-     * The Levenshtein distance between the Text fragments of the `StepTemplate` and the aligned scenario step.
+     * The editing distance between the Text fragments of the `StepTemplate` and the aligned scenario step.
      */
     val distance: Int by lazy {
         distanceMatrix.last().last()
@@ -43,25 +50,13 @@ internal class Alignment(
         if (!isMisaligned()) buildAlignedStrings() else Pair(stepTemplate.toString(), step)
     }
 
-    private val distanceMatrix: DistanceMatrix by lazy {
+    val distanceMatrix: DistanceMatrix by lazy {
         constructDistanceMatrix(stepTemplate, step)
     }
-
-    private val costInsertion = 1
-    private val costDeletion = 1
-    private val costSubstitution = 1
-    private val costVariableExpansion = 0
-    private val costVariableDeletion = 0
 
     /**
      * Calculates the distance matrix. Think of this as putting the `StepTemplate` and the scenario step next to
      * each other and judging how well the template fits to the step.
-     *
-     * To calculate an optimal global alignment of the `StepTemplate` and the String `s` representing the scenario step,
-     * we use an adapted version of the Needleman-Wunsch algorithm. The algorithm runs in to phases:
-     *
-     * 1. construct a distance matrix
-     * 2. trace an optimal path back through the matrix to the origin
      *
      * The following shows the first part of a distance matrix for the template "User {name} has entered the building."
      * and the scenario step "User Peter has entered the building."
@@ -85,10 +80,10 @@ internal class Alignment(
      * stepTemplate("User ", name, " has entered the building.")
      * ```
      *
-     * The matrix tracks the Levenshtein distance for all pairs of substrings of the `StepTemplate` and `s`. Characters
+     * The matrix tracks the editing distance for all pairs of substrings of the `StepTemplate` and `s`. Characters
      * aligned with a variable do not count towards that distance.
      *
-     * Distance grow monotonically from the top-left origin to the bottom-right. No row can contain a distance smaller
+     * Distance grows monotonically from the top-left origin to the bottom-right. No row can contain a distance smaller
      * than the smallest value of the previous row. Because calculating the entire matrix is O(n²) in time, we can abort
      * the calculation, once the minimum value in a row exceeds `maxDistance` and it becomes obvious that the template
      * does not match the scenario step.
@@ -103,15 +98,14 @@ internal class Alignment(
         var offset = 1
         for (fragment in stepTemplate.fragments) {
             for (i in offset..offset + length(fragment) - 1) {
-                when(fragment) {
+                when (fragment) {
                     is Text -> {
-                        d[i][0] = d[i - 1][0] + costDeletion
+                        d[i][0] = d[i - 1][0] + costDeletion(fragment.content[i - offset])
                         var currentMinDistance = d[i][0]
                         for (j in 1..s.length) {
                             d[i][j] = d[i][j - 1] + costInsertion
-                            d[i][j] = min(d[i][j], d[i - 1][j] + costDeletion)
-                            d[i][j] = min(d[i][j], d[i - 1][j - 1]
-                                    + if (fragment.content[i - offset] != s[j - 1]) costSubstitution else 0)
+                            d[i][j] = min(d[i][j], d[i - 1][j] + costDeletion(fragment.content[i - offset]))
+                            d[i][j] = min(d[i][j], d[i - 1][j - 1] + costSubstitution(fragment.content[i - offset], s[j - 1]))
                             currentMinDistance = min(currentMinDistance, d[i][j])
                         }
                         if (currentMinDistance > maxDistance) {
@@ -123,8 +117,8 @@ internal class Alignment(
                         d[offset][0] = d[offset - 1][0] + costVariableDeletion
                         for (j in 1..s.length) {
                             d[offset][j] = d[offset - 1][j] + costVariableDeletion
-                            d[offset][j] = min(d[offset][j], d[offset][j - 1] + costVariableExpansion)
-                            d[offset][j] = min(d[offset][j], d[offset - 1][j - 1] + costVariableExpansion)
+                            d[offset][j] = min(d[offset][j], d[offset][j - 1] + costVariableExtension(s[j - 1]))
+                            d[offset][j] = min(d[offset][j], d[offset - 1][j - 1] + costVariableExtension(s[j - 1]))
                         }
                     }
                 }
@@ -135,6 +129,46 @@ internal class Alignment(
         return d
     }
 
+
+    /* The following values define how we calculate the editing distance between template and step. */
+
+    private val costInsertion = 1
+    private val costSimpleDeletion = 1
+    private val costDeletedQuotationChar = maxDistance
+
+    private fun costDeletion(deletedCharInFragment: Char): Int {
+        return if (stepTemplate.quotationCharacters.contains(deletedCharInFragment))
+            costDeletedQuotationChar
+        else
+            costSimpleDeletion
+    }
+
+    private val costMatchingCharacters = 0
+    private val costSimpleSubstitution = 1
+    private val costSubstitutedQuotationChar = maxDistance
+
+    private fun costSubstitution(inFragment: Char, inStep: Char): Int {
+        return if (inFragment != inStep) {
+            if (stepTemplate.quotationCharacters.contains(inFragment))
+                costSubstitutedQuotationChar
+            else
+                costSimpleSubstitution
+        } else
+            costMatchingCharacters
+    }
+
+    private val costVariableSimpleExtension = 0
+    private val costVariableExtensionOverQuotationChar = maxDistance
+
+    private fun costVariableExtension(extension: Char): Int {
+        return if (stepTemplate.quotationCharacters.contains(extension))
+            costVariableExtensionOverQuotationChar
+        else
+            costVariableSimpleExtension
+    }
+
+    private val costVariableDeletion = 0
+
     /**
      * Extracts the variables from the scenario step and returns them as a map of variable names to their respective
      * values.
@@ -143,30 +177,27 @@ internal class Alignment(
         val variables = mutableMapOf<String, String>()
         var currentValue = ""
 
-        backtrace(object : TracebackHandler {
-            override fun handleMatchOrSubstitution(fragment: Fragment, fragmentIndex: Int, stepIndex: Int) {
-                if (fragment is Variable) {
-                    currentValue = step[stepIndex] + currentValue
-                    variables[fragment.name] = currentValue
-                } else {
-                    currentValue = ""
-                }
-            }
-
-            override fun handleInsertion(fragment: Fragment, fragmentIndex: Int, stepIndex: Int) {
-                if (fragment is Variable) {
-                    currentValue = step[stepIndex] + currentValue
-                }
-            }
-
-            override fun handleDeletion(fragment: Fragment, fragmentIndex: Int, stepIndex: Int) {
-                if (fragment is Variable) {
-                    variables[fragment.name] = currentValue
-                } else {
-                    currentValue = ""
-                }
-            }
-        })
+        backtrace(
+                onMatchOrSubstitution = { fragment, _, stepIndex ->
+                    if (fragment is Variable) {
+                        currentValue = step[stepIndex] + currentValue
+                        variables[fragment.name] = currentValue
+                    } else {
+                        currentValue = ""
+                    }
+                },
+                onInsertion = { fragment, _, stepIndex ->
+                    if (fragment is Variable) {
+                        currentValue = step[stepIndex] + currentValue
+                    }
+                },
+                onDeletion = { fragment, _, _ ->
+                    if (fragment is Variable) {
+                        variables[fragment.name] = currentValue
+                    } else {
+                        currentValue = ""
+                    }
+                })
 
         return variables
     }
@@ -179,40 +210,29 @@ internal class Alignment(
         var alignedTemplate = ""
         var alignedString = ""
 
-        backtrace(object : TracebackHandler {
-            override fun handleMatchOrSubstitution(fragment: Fragment, fragmentIndex: Int, stepIndex: Int) {
-                alignedTemplate = fragmentChar(fragment, fragmentIndex) + alignedTemplate
-                alignedString = step[stepIndex] + alignedString
-            }
-
-            override fun handleInsertion(fragment: Fragment, fragmentIndex: Int, stepIndex: Int) {
-                val gap = if (fragment is Text) '-' else 'X'
-                alignedTemplate = gap + alignedTemplate
-                alignedString = step[stepIndex] + alignedString
-            }
-
-            override fun handleDeletion(fragment: Fragment, fragmentIndex: Int, stepIndex: Int) {
-                alignedTemplate = fragmentChar(fragment, fragmentIndex) + alignedTemplate
-                alignedString = "-" + alignedString
-            }
-
-            private fun fragmentChar(fragment: Fragment, index: Int): Char {
-                return if (fragment is Text) fragment.content[index] else 'X'
-            }
-        })
+        backtrace(
+                onMatchOrSubstitution = { fragment, fragmentIndex, stepIndex ->
+                    val fragmentChar = if (fragment is Text) fragment.content[fragmentIndex] else 'X'
+                    alignedTemplate = fragmentChar + alignedTemplate
+                    alignedString = step[stepIndex] + alignedString
+                },
+                onInsertion = { fragment, _, stepIndex ->
+                    val gap = if (fragment is Text) '-' else 'X'
+                    alignedTemplate = gap + alignedTemplate
+                    alignedString = step[stepIndex] + alignedString
+                },
+                onDeletion = { fragment, fragmentIndex, _ ->
+                    val fragmentChar = if (fragment is Text) fragment.content[fragmentIndex] else 'X'
+                    alignedTemplate = fragmentChar + alignedTemplate
+                    alignedString = "-" + alignedString
+                })
 
         return Pair(alignedTemplate, alignedString)
     }
 
-    private interface TracebackHandler {
-        fun handleMatchOrSubstitution(fragment: Fragment, fragmentIndex: Int, stepIndex: Int)
-        fun handleInsertion(fragment: Fragment, fragmentIndex: Int, stepIndex: Int)
-        fun handleDeletion(fragment: Fragment, fragmentIndex: Int, stepIndex: Int)
-    }
-
     /**
      * Performs the second phase of the Needleman-Wunsch algorithm: tracing back a path through the distance
-     * matrix to determine an optimal global alignment. Such a path follows the smallest Levenshtein distance
+     * matrix to determine an optimal global alignment. Such a path follows the smallest editing distance
      * back to the origin:
      *
      * ```
@@ -237,7 +257,7 @@ internal class Alignment(
      * Each step along that path corresponds to an editing action (match or substitution, insertion, deletion). It falls
      * to the supplied handler to decide how each operation is processed.
      */
-    private fun backtrace(handler: TracebackHandler) {
+    private fun backtrace(onMatchOrSubstitution: BacktraceHandler, onInsertion: BacktraceHandler, onDeletion: BacktraceHandler) {
         var offset = stepTemplate.length()
         var i = offset
         var j = step.length
@@ -248,25 +268,27 @@ internal class Alignment(
                         && distanceMatrix[i - 1][j - 1] <= distanceMatrix[i - 1][j]
                         && distanceMatrix[i - 1][j - 1] <= distanceMatrix[i][j - 1]) {
                     --i; --j
-                    handler.handleMatchOrSubstitution(fragment, i - offset, j)
+                    onMatchOrSubstitution(fragment, i - offset, j)
                 } else if (i > offset && (j == 0 || distanceMatrix[i - 1][j] <= distanceMatrix[i][j - 1])) {
                     --i
-                    handler.handleDeletion(fragment, i - offset, j)
+                    onDeletion(fragment, i - offset, j)
                 } else {
                     assert(j > 0)
                     --j
-                    handler.handleInsertion(fragment, i - offset, j)
+                    onInsertion(fragment, i - offset, j)
                 }
             }
         }
     }
 }
 
-typealias DistanceMatrix = Array<IntArray>
+internal typealias DistanceMatrix = Array<IntArray>
+
+private typealias BacktraceHandler = (fragment: Fragment, fragmentIndex: Int, stepIndex: Int) -> Unit
 
 private fun StepTemplate.length() = fragments.map { length(it) }.sum()
 
-private fun length(fragment: Fragment): Int = when(fragment) {
+private fun length(fragment: Fragment): Int = when (fragment) {
     is Text -> fragment.content.length
     else -> 1
 }

--- a/livingdoc-engine/src/main/kotlin/org/livingdoc/engine/executor/scenario/ScenarioStepMatcher.kt
+++ b/livingdoc-engine/src/main/kotlin/org/livingdoc/engine/executor/scenario/ScenarioStepMatcher.kt
@@ -9,8 +9,8 @@ internal class ScenarioStepMatcher(val stepTemplates: List<StepTemplate>) {
 
     fun match(step: String): MatchingResult {
         val bestAlignment = stepTemplates
-                .map { it.alignWith(step, maxDistance = 15) }
-                .minBy { it.distance }
+                .map { it.alignWith(step, maxCostOfAlignment = 15) }
+                .minBy { it.totalCost }
         if (bestAlignment == null || bestAlignment.isMisaligned()) {
             throw NoMatchingStepTemplate("No matching template!")
         }

--- a/livingdoc-engine/src/main/kotlin/org/livingdoc/engine/executor/scenario/StepTemplate.kt
+++ b/livingdoc-engine/src/main/kotlin/org/livingdoc/engine/executor/scenario/StepTemplate.kt
@@ -30,7 +30,7 @@ internal class StepTemplate(
     /**
      * Returns an `Alignment` of the template and the specified scenario step.
      */
-    fun alignWith(step: String, maxDistance: Int = 20) = Alignment(this, step, maxDistance)
+    fun alignWith(step: String, maxCostOfAlignment: Int = 20) = Alignment(this, step, maxCostOfAlignment)
 
     override fun toString(): String = fragments.joinToString(separator = "") {
         when (it) {

--- a/livingdoc-engine/src/test/kotlin/org/livingdoc/engine/executor/scenario/AlignmentTest.kt
+++ b/livingdoc-engine/src/test/kotlin/org/livingdoc/engine/executor/scenario/AlignmentTest.kt
@@ -1,112 +1,218 @@
 package org.livingdoc.engine.executor.scenario
 
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.AbstractAssert
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-
 
 class AlignmentTest {
 
-    @Test
-    fun `aligns StepTemplate with no variables with perfectly matching string`() {
-        val alignment = align("Elvis has left the building.", "Elvis has left the building.")
-        assertThat(alignment.distance).isEqualTo(0)
+    @Nested inner class `given a StepTemplate without variables` {
+
+        @Test fun `aligns perfectly matching step`() {
+            val alignment = align("Elvis has left the building.", "Elvis has left the building.")
+            assertThat(alignment).hasNoVariables().hasDistance(0)
+        }
+
+        @Test fun `aligns similar step`() {
+            val alignment = align("Elvis has left the building.", "Peter has left the building.")
+            assertThat(alignment)
+                    .hasNoVariables()
+                    .hasDistance(5)
+                    .alignsAs("Elvis has left the building.", "Peter has left the building.")
+        }
+
+        @Test fun `aligns empty string`() {
+            val alignment = align("Elvis likes pizza.", "")
+            assertThat(alignment)
+                    .hasNoVariables()
+                    .hasDistance(18)
+                    .alignsAs("Elvis likes pizza.", "------------------")
+        }
     }
 
-    @Test
-    fun `aligns StepTemplate with no variables with similar string`() {
-        val alignment = align("Elvis has left the building.", "Peter has left the building.")
-        assertThat(alignment.distance).isEqualTo(5)
-        assertThat(alignment.alignedStrings).isEqualTo(Pair(
-                "Elvis has left the building.",
-                "Peter has left the building."
-        ))
+
+    @Nested inner class `given a StepTemplate with variables` {
+
+        @Test fun `extracts value from perfectly matching step`() {
+            val alignment = align("User {username} has entered the building.", "User Peter has entered the building.")
+            assertThat(alignment)
+                    .hasDistance(0)
+                    .hasVariables("username" to "Peter")
+                    .alignsAs("User XXXXX has entered the building.", "User Peter has entered the building.")
+        }
+
+        @Test fun `extracts value from step with slightly different text fragments`() {
+            val alignment = align("User {user} has entered the building.", "A user Peter has left the building.")
+            assertThat(alignment)
+                    .hasDistance(9)
+                    .hasVariables("user" to "Peter")
+                    .alignsAs("--User XXXXX has entered the building.", "A user Peter has --le-ft the building.")
+        }
+
+        @Test fun `extracts value from step when the variable is the first part of the template`() {
+            val alignment = align("{username} has entered the building.", "Peter has left the building.")
+            assertThat(alignment)
+                    .hasDistance(6)
+                    .hasVariables("username" to "Peter")
+                    .alignsAs("XXXXX has entered the building.", "Peter has --le-ft the building.")
+        }
+
+        @Test fun `extracts all of the values`() {
+            val alignment = align("{username} has {action} the {object}.", "Peter has left the building.")
+            assertThat(alignment)
+                    .hasDistance(0)
+                    .hasVariables(
+                            "username" to "Peter",
+                            "action" to "left",
+                            "object" to "building")
+                    .alignsAs(
+                            "XXXXX has XXXX the XXXXXXXX.",
+                            "Peter has left the building.")
+        }
+
+        @Test fun `extracts empty string as value from perfectly matching step`() {
+            val alignment = align("My name is {username}.", "My name is .")
+            assertThat(alignment)
+                    .hasDistance(0)
+                    .hasVariables("username" to "")
+                    .alignsAs(
+                            "My name is X.",
+                            "My name is -.")
+        }
     }
 
-    @Test
-    fun `aligns empty string`() {
-        val alignment = align("Elvis likes pizza.", "")
-        assertThat(alignment.distance).isEqualTo(18)
-        assertThat(alignment.alignedStrings).isEqualTo(Pair(
-                "Elvis likes pizza.",
-                "------------------"))
-    }
 
-    @Test
-    fun `aligns StepTemplate with single variable with perfectly matching string`() {
-        val alignment = align("User {username} has entered the building.", "User Peter has entered the building.")
-        assertThat(alignment.distance).isEqualTo(0)
-        assertThat(alignment.variables).isEqualTo(mapOf("username" to "Peter"))
-        assertThat(alignment.alignedStrings).isEqualTo(Pair(
-                "User XXXXX has entered the building.",
-                "User Peter has entered the building."
-        ))
-    }
-
-    @Test
-    fun `aligns StepTemplate with single variable and slightly different text fragment`() {
-        val alignment = align("User {user} has entered the building.", "A user Peter has left the building.")
-        assertThat(alignment.distance).isEqualTo(9)
-        assertThat(alignment.variables).isEqualTo(mapOf("user" to "Peter"))
-        assertThat(alignment.alignedStrings).isEqualTo(Pair(
-                "--User XXXXX has entered the building.",
-                "A user Peter has --le-ft the building."
-        ))
-    }
-
-    @Test
-    fun `aligns StepTemplate starting with a variable`() {
-        val alignment = align("{username} has entered the building.", "Peter has left the building.")
-        assertThat(alignment.distance).isEqualTo(6)
-        assertThat(alignment.variables).isEqualTo(mapOf("username" to "Peter"))
-        assertThat(alignment.alignedStrings).isEqualTo(Pair(
-                "XXXXX has entered the building.",
-                "Peter has --le-ft the building."
-        ))
-    }
-
-    @Test
-    fun `aligns StepTemplate with multiple variables`() {
-        val alignment = align("{username} has {action} the {object}.", "Peter has left the building.")
-        assertThat(alignment.distance).isEqualTo(0)
-        assertThat(alignment.variables).isEqualTo(mapOf(
-                "username" to "Peter",
-                "action" to "left",
-                "object" to "building"))
-        assertThat(alignment.alignedStrings).isEqualTo(Pair(
-                "XXXXX has XXXX the XXXXXXXX.",
-                "Peter has left the building."
-        ))
-    }
-
-    @Test
-    fun `aligns optimally if a single variable remains empty`() {
-        val alignment = align("My name is {username}.", "My name is .")
-        assertThat(alignment.distance).isEqualTo(0)
-        assertThat(alignment.variables).isEqualTo(mapOf("username" to ""))
-        assertThat(alignment.alignedStrings).isEqualTo(Pair(
-                "My name is X.",
-                "My name is -."
-        ))
-    }
-
-    @Test
-    fun `is misaligned when distance becomes too large`() {
+    @Test fun `given no matching StepTemplate, it is misaligned`() {
         val alignment = align(
                 "Elvis left the building and this is a really long sentence that doesn't align with the next one at all.",
                 "Peter likes pizza.")
-        assertThat(alignment.isMisaligned()).isEqualTo(true)
-        assertThat(alignment.distance).isEqualTo(21)
-        assertThat(alignment.variables).isEmpty()
-        assertThat(alignment.alignedStrings).isEqualTo(Pair(
-                "Elvis left the building and this is a really long sentence that doesn't align with the next one at all.",
-                "Peter likes pizza."
-        ))
+
+        assertThat(alignment)
+                .isMisaligned()
+                .alignsAs(
+                        "Elvis left the building and this is a really long sentence that doesn't align with the next one at all.",
+                        "Peter likes pizza.")
+                .hasNoVariables()
+        Assertions.assertThat(alignment.maxDistance <= alignment.distance).isTrue()
     }
+
+
+    @Nested inner class `given a StepTemplate with quotation characters` {
+
+        @Test fun `extracts variables from perfectly matching step`() {
+            val alignment = alignWithPunctuation("{user} likes '{stuff}'.", "Peter likes 'Pizza'.")
+            assertThat(alignment)
+                    .alignsAs("XXXXX likes 'XXXXX'.", "Peter likes 'Pizza'.")
+                    .hasVariables("user" to "Peter", "stuff" to "Pizza")
+        }
+
+        @Test fun `extracts variable with adjacent insertion`() {
+            val alignment = alignWithPunctuation("'{user}' likes '{stuff}'.", "'Peter' likes delicious 'Pizza'.")
+            assertThat(alignment)
+                    .hasVariables("user" to "Peter", "stuff" to "Pizza")
+                    .alignsAs("'XXXXX' likes ----------'XXXXX'.", "'Peter' likes delicious 'Pizza'.")
+        }
+
+        @Test fun `is misaligned, if a quotation character is missed in the step`() {
+            val alignment = alignWithPunctuation(
+                    "Peter does not like '{stuff}'.",
+                    "Peter does not like missing punctuation marks'.")
+            assertThat(alignment).isMisaligned()
+        }
+
+        @Test fun `extracted variables do not contain quotation characters`() {
+            val alignment = alignWithPunctuation(
+                    "Peter does not like '{stuff}'.",
+                    "Peter does not like ''unnecessary quotation marks'.")
+            Assertions.assertThat(alignment.variables["stuff"]).doesNotContain("'")
+            assertThat(alignment)
+                    .hasVariables("stuff" to "unnecessary quotation marks")
+                    .hasDistance(1) // due to insertion of the unnecessary single quotation mark
+        }
+
+        private fun alignWithPunctuation(templateString: String, step: String): Alignment {
+            return Alignment(StepTemplate.parse(templateString, quotationCharacters = setOf('\'')), step, maxDistance = 20)
+        }
+    }
+
 
     private fun align(templateString: String, step: String): Alignment {
         return Alignment(StepTemplate.parse(templateString), step, maxDistance = 20)
     }
 
+}
+
+
+private fun assertThat(actual: Alignment) = AlignmentAssert(actual)
+
+private class AlignmentAssert(actual: Alignment)
+    : AbstractAssert<AlignmentAssert, Alignment>(actual, AlignmentAssert::class.java) {
+
+    fun hasDistance(distance: Int): AlignmentAssert {
+        if (actual.distance != distance)
+            failWithMessage("Expected an editing distance of $distance, but was ${actual.distance}")
+        return this
+    }
+
+    fun isMisaligned(): AlignmentAssert {
+        if (!actual.isMisaligned())
+            failWithMessage("Expected alignment to be misaligned, but it was not.")
+        return this
+    }
+
+    fun alignsAs(template: String, step: String): AlignmentAssert {
+        if (actual.alignedStrings != Pair(template, step)) {
+            val reason = if (actual.alignedStrings.first != template)
+                "the template is aligned differently"
+            else if (actual.alignedStrings.second != step)
+                "the step is aligned differently"
+            else
+                "both template and step are aligned differently"
+
+            failWithMessage("Expected alignment\n\t(template) %s\n\t    (step) %s\n" +
+                    "to be equal to\n\t(template) %s\n\t    (step) %s\nbut %s.",
+                    actual.alignedStrings.first, actual.alignedStrings.second, template, step, reason)
+        }
+        return this
+    }
+
+    fun hasNoVariables(): AlignmentAssert {
+        if (!actual.variables.isEmpty())
+            failWithMessage("Expected alignment with no variables, but there are:\n%s",
+                    formatVariables(actual.variables))
+        return this
+    }
+
+    fun hasVariables(vararg variables: Pair<String, String>): AlignmentAssert {
+        val variablesToValues = variables.toMap()
+        val missingVariables = variablesToValues.keys.subtract(actual.variables.keys)
+        val unexpectedVariables = actual.variables.keys.subtract(variablesToValues.keys)
+        val wrongValues = variablesToValues.keys
+                .intersect(actual.variables.keys)
+                .filter { variablesToValues[it] != actual.variables[it] }
+
+        if (missingVariables.isNotEmpty() || unexpectedVariables.isNotEmpty() || wrongValues.isNotEmpty()) {
+            val reasons = mutableListOf<String>()
+            if (missingVariables.isNotEmpty())
+                reasons.add("is missing " + missingVariables.joinToString { "'$it'" })
+            if (unexpectedVariables.isNotEmpty())
+                reasons.add("unexpectedly also yields " + unexpectedVariables.joinToString { "'$it'" })
+            if (wrongValues.isNotEmpty())
+                wrongValues.forEach {
+                    reasons.add("the value of '$it' was '${actual.variables[it]}', not '${variablesToValues[it]}'")
+                }
+
+            failWithMessage("Expected alignment yielding the variables\n%s\nto yield\n%s\nbut it %s.",
+                    formatVariables(actual.variables),
+                    formatVariables(variablesToValues),
+                    reasons.joinToString(separator = "\n\tand "))
+        }
+        return this
+    }
+
+    private fun formatVariables(variables: Map<String, String>)
+            = variables.asIterable().joinToString(separator = "\n\t", prefix = "\t") { "${it.key} = ${it.value}" }
 }
 
 

--- a/livingdoc-engine/src/test/kotlin/org/livingdoc/engine/executor/scenario/AlignmentTest.kt
+++ b/livingdoc-engine/src/test/kotlin/org/livingdoc/engine/executor/scenario/AlignmentTest.kt
@@ -5,29 +5,38 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+
+private val PRINT_DEBUG_OUTPUT = false
+
 class AlignmentTest {
 
     @Nested inner class `given a StepTemplate without variables` {
 
         @Test fun `aligns perfectly matching step`() {
             val alignment = align("Elvis has left the building.", "Elvis has left the building.")
-            assertThat(alignment).hasNoVariables().hasDistance(0)
+            assertThat(alignment)
+                    .hasNoVariables()
+                    .alignsAs(
+                            "Elvis has left the building.",
+                            "Elvis has left the building.")
         }
 
         @Test fun `aligns similar step`() {
-            val alignment = align("Elvis has left the building.", "Peter has left the building.")
+            val alignment = align("Elvis has entered the building.", "Peter has left the building.")
             assertThat(alignment)
                     .hasNoVariables()
-                    .hasDistance(5)
-                    .alignsAs("Elvis has left the building.", "Peter has left the building.")
+                    .alignsAs(
+                            "Elvis has -entered the building.",
+                            "Peter has left---- the building.")
         }
 
         @Test fun `aligns empty string`() {
             val alignment = align("Elvis likes pizza.", "")
             assertThat(alignment)
                     .hasNoVariables()
-                    .hasDistance(18)
-                    .alignsAs("Elvis likes pizza.", "------------------")
+                    .alignsAs(
+                            "Elvis likes pizza.",
+                            "------------------")
         }
     }
 
@@ -36,45 +45,30 @@ class AlignmentTest {
 
         @Test fun `extracts value from perfectly matching step`() {
             val alignment = align("User {username} has entered the building.", "User Peter has entered the building.")
-            assertThat(alignment)
-                    .hasDistance(0)
-                    .hasVariables("username" to "Peter")
-                    .alignsAs("User XXXXX has entered the building.", "User Peter has entered the building.")
+            assertThat(alignment).hasVariables("username" to "Peter")
         }
 
         @Test fun `extracts value from step with slightly different text fragments`() {
             val alignment = align("User {user} has entered the building.", "A user Peter has left the building.")
-            assertThat(alignment)
-                    .hasDistance(9)
-                    .hasVariables("user" to "Peter")
-                    .alignsAs("--User XXXXX has entered the building.", "A user Peter has --le-ft the building.")
+            assertThat(alignment).hasVariables("user" to "Peter")
         }
 
         @Test fun `extracts value from step when the variable is the first part of the template`() {
             val alignment = align("{username} has entered the building.", "Peter has left the building.")
-            assertThat(alignment)
-                    .hasDistance(6)
-                    .hasVariables("username" to "Peter")
-                    .alignsAs("XXXXX has entered the building.", "Peter has --le-ft the building.")
+            assertThat(alignment).hasVariables("username" to "Peter")
         }
 
         @Test fun `extracts all of the values`() {
             val alignment = align("{username} has {action} the {object}.", "Peter has left the building.")
-            assertThat(alignment)
-                    .hasDistance(0)
-                    .hasVariables(
-                            "username" to "Peter",
-                            "action" to "left",
-                            "object" to "building")
-                    .alignsAs(
-                            "XXXXX has XXXX the XXXXXXXX.",
-                            "Peter has left the building.")
+            assertThat(alignment).hasVariables(
+                    "username" to "Peter",
+                    "action" to "left",
+                    "object" to "building")
         }
 
         @Test fun `extracts empty string as value from perfectly matching step`() {
             val alignment = align("My name is {username}.", "My name is .")
             assertThat(alignment)
-                    .hasDistance(0)
                     .hasVariables("username" to "")
                     .alignsAs(
                             "My name is X.",
@@ -94,64 +88,69 @@ class AlignmentTest {
                         "Elvis left the building and this is a really long sentence that doesn't align with the next one at all.",
                         "Peter likes pizza.")
                 .hasNoVariables()
-        Assertions.assertThat(alignment.maxDistance <= alignment.distance).isTrue()
+        Assertions.assertThat(alignment.maxCost <= alignment.totalCost).isTrue()
     }
 
 
     @Nested inner class `given a StepTemplate with quotation characters` {
 
-        @Test fun `extracts variables from perfectly matching step`() {
-            val alignment = alignWithPunctuation("{user} likes '{stuff}'.", "Peter likes 'Pizza'.")
-            assertThat(alignment)
-                    .alignsAs("XXXXX likes 'XXXXX'.", "Peter likes 'Pizza'.")
-                    .hasVariables("user" to "Peter", "stuff" to "Pizza")
+        @Test fun `extracts variable from perfectly matching step`() {
+            val alignment = alignWithQuotationCharacters("Peter likes '{stuff}'.", "Peter likes 'Pizza'.")
+            assertThat(alignment).hasVariables("stuff" to "Pizza")
         }
 
         @Test fun `extracts variable with adjacent insertion`() {
-            val alignment = alignWithPunctuation("'{user}' likes '{stuff}'.", "'Peter' likes delicious 'Pizza'.")
-            assertThat(alignment)
-                    .hasVariables("user" to "Peter", "stuff" to "Pizza")
-                    .alignsAs("'XXXXX' likes ----------'XXXXX'.", "'Peter' likes delicious 'Pizza'.")
+            val alignment = alignWithQuotationCharacters("'{user}' likes '{stuff}'.", "'Peter' likes delicious 'Pizza'.")
+            assertThat(alignment).hasVariables("user" to "Peter", "stuff" to "Pizza")
         }
 
-        @Test fun `is misaligned, if a quotation character is missed in the step`() {
-            val alignment = alignWithPunctuation(
+        @Test fun `extracts from quoted and unquoted variables in the same template`() {
+            val alignment = alignWithQuotationCharacters("{user} likes '{stuff}'.", "Peter likes delicious 'Pizza'.")
+            assertThat(alignment).hasVariables("user" to "Peter", "stuff" to "Pizza")
+        }
+
+        @Test fun `is misaligned, if a quotation character is missing in the step`() {
+            val alignment = alignWithQuotationCharacters(
                     "Peter does not like '{stuff}'.",
                     "Peter does not like missing punctuation marks'.")
             assertThat(alignment).isMisaligned()
         }
 
         @Test fun `extracted variables do not contain quotation characters`() {
-            val alignment = alignWithPunctuation(
+            val alignment = alignWithQuotationCharacters(
                     "Peter does not like '{stuff}'.",
                     "Peter does not like ''unnecessary quotation marks'.")
             Assertions.assertThat(alignment.variables["stuff"]).doesNotContain("'")
-            assertThat(alignment)
-                    .hasVariables("stuff" to "unnecessary quotation marks")
-                    .hasDistance(1) // due to insertion of the unnecessary single quotation mark
+            assertThat(alignment).hasVariables("stuff" to "unnecessary quotation marks")
         }
 
-        private fun alignWithPunctuation(templateString: String, step: String): Alignment {
-            return Alignment(StepTemplate.parse(templateString, quotationCharacters = setOf('\'')), step, maxDistance = 20)
+        private fun alignWithQuotationCharacters(templateString: String, step: String): Alignment {
+            return Alignment(StepTemplate.parse(templateString, quotationCharacters = setOf('\'')), step, maxCost = MAX_DISTANCE)
         }
     }
 
 
     private fun align(templateString: String, step: String): Alignment {
-        return Alignment(StepTemplate.parse(templateString), step, maxDistance = 20)
+        return Alignment(StepTemplate.parse(templateString), step, maxCost = MAX_DISTANCE)
     }
 
+    private val MAX_DISTANCE = 40 // allow for 20 insertions (a bit much, but useful for the examples in this test)
 }
 
-
-private fun assertThat(actual: Alignment) = AlignmentAssert(actual)
+private fun assertThat(actual: Alignment): AlignmentAssert {
+    if (PRINT_DEBUG_OUTPUT) {
+        printDistanceMatrix(actual)
+        printAlignment(actual)
+    }
+    return AlignmentAssert(actual)
+}
 
 private class AlignmentAssert(actual: Alignment)
     : AbstractAssert<AlignmentAssert, Alignment>(actual, AlignmentAssert::class.java) {
 
-    fun hasDistance(distance: Int): AlignmentAssert {
-        if (actual.distance != distance)
-            failWithMessage("Expected an editing distance of $distance, but was ${actual.distance}")
+    fun hasTotalCost(cost: Int): AlignmentAssert {
+        if (actual.totalCost != cost)
+            failWithMessage("Expected a total cost of $cost, but was ${actual.totalCost}")
         return this
     }
 
@@ -195,16 +194,20 @@ private class AlignmentAssert(actual: Alignment)
         if (missingVariables.isNotEmpty() || unexpectedVariables.isNotEmpty() || wrongValues.isNotEmpty()) {
             val reasons = mutableListOf<String>()
             if (missingVariables.isNotEmpty())
-                reasons.add("is missing " + missingVariables.joinToString { "'$it'" })
+                reasons.add("it is missing " + missingVariables.joinToString { "'$it'" })
             if (unexpectedVariables.isNotEmpty())
-                reasons.add("unexpectedly also yields " + unexpectedVariables.joinToString { "'$it'" })
+                reasons.add("it unexpectedly also yields " + unexpectedVariables.joinToString { "'$it'" })
             if (wrongValues.isNotEmpty())
                 wrongValues.forEach {
                     reasons.add("the value of '$it' was '${actual.variables[it]}', not '${variablesToValues[it]}'")
                 }
 
-            failWithMessage("Expected alignment yielding the variables\n%s\nto yield\n%s\nbut it %s.",
-                    formatVariables(actual.variables),
+            val description = if (actual.variables.isEmpty())
+                "with no variables "
+            else
+                String.format("yielding the variables\n%s\n", formatVariables(actual.variables))
+            failWithMessage("Expected alignment %sto yield\n%s\nbut %s.",
+                    description,
                     formatVariables(variablesToValues),
                     reasons.joinToString(separator = "\n\tand "))
         }
@@ -217,15 +220,23 @@ private class AlignmentAssert(actual: Alignment)
 
 
 /**
- * Prints the distance matrix `d` for the string `s` to the standard output. Useful for debugging.
+ * Prints the distance matrix of the given alignment.
  */
-fun printDistanceMatrix(s: String, d: DistanceMatrix) {
+private fun printDistanceMatrix(alignment: Alignment) {
     print("   ")
-    s.forEach { print(String.format("%3c", it)) }
+    alignment.step.forEach { print(String.format("%3c", it)) }
     println()
-    for (line in d) {
+    for (line in alignment.distanceMatrix) {
         line.forEach { print(String.format("%3d", it)) }
         println()
     }
+}
+
+/**
+ * Prints the aligned strings of template and step for the given alignment.
+ */
+private fun printAlignment(alignment: Alignment) {
+    println("\t(template) ${alignment.alignedStrings.first}" +
+            "\n\t    (step) ${alignment.alignedStrings.second}")
 }
 

--- a/livingdoc-engine/src/test/kotlin/org/livingdoc/engine/executor/scenario/StepTemplateTest.kt
+++ b/livingdoc-engine/src/test/kotlin/org/livingdoc/engine/executor/scenario/StepTemplateTest.kt
@@ -43,6 +43,12 @@ class StepTemplateTest {
         }
 
         @Test
+        fun `accepts optional set of quotation characters`() {
+            val cut = StepTemplate.parse("{user} enters the building.", setOf('\''))
+            assertThat(cut.quotationCharacters).containsExactly('\'')
+        }
+
+        @Test
         fun `parses StepTemplates with multiple variables`() {
             val cut = StepTemplate.parse("The user {user} enters a value for {variable}: {value}")
             assertThat(cut.fragments).containsExactly(
@@ -67,7 +73,6 @@ class StepTemplateTest {
                 StepTemplate.parse("Two {consecutive}{variables} cannot be separated by a matcher.")
             }
         }
-
     }
 
     @Test


### PR DESCRIPTION
This makes the alignment algorithm aware of optional quotation characters for
variable separation. They can be used for disambiguation in case of an
insertion that is adjacent to, but not supposed to be part of a variable.

Given the following alignment:
```
    Peter likes {food}.
    Peter likes -Pizza. (food = "Pizza")
```

Suppose, we insert an adjective in front of food:
```
    Peter likes {     food    }.
    Peter likes delicious Pizza. (food = "delicious Pizza")
```

If we don't want the insertion included, we can use quotation:
```
    Peter likes --------- '{food}'.
    Peter likes delicious '-Pizza'. (food = "Pizza")
```